### PR TITLE
ETHBerlin 5 -> ETHBerlin 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ research and community of [Web3Privacy Now](https://web3privacy.info).
 | meetup | `itxx` | 2024/Q1 | 🇮🇹 Italy (TBD) | - |  | PG |  |
 | meetup | `lib1` | 2024/Mar | 🇨🇿 Liberec | - | [ETHBohemia](https://ethbohemia.ethevents.club/) | Tree |  |
 | meetup | `ams1` | 2024/Apr | 🇳🇱 Amsterdam | - | [ETHDam 2024](https://www.ethdam.com/) | - |  |
-| meetup | `ber1` | 2024/May | 🇩🇪 Berlin | - | ETHBerlin 5 | Tree |  |
+| meetup | `ber1` | 2024/May | 🇩🇪 Berlin | - | ETHBerlin 4 | Tree |  |
 | summit | `s2` | 2024/Jun | 🇨🇿 Prague | - | ETHPrague 2024 | Tree |  |
 | hackathon | `h1` | 2024/Jun | 🇸🇮 Bled | - |  | Tree |  |
 | meetup | `lju1` | 2024/Jun | 🇸🇮 Ljubljana | - | W3PN Hackathon | Tree |  |


### PR DESCRIPTION
We recently had rough consensus that it will be called ETHBerlin 4 even though it might cause problems for people with Tetraphobia - but having 4 in 2024 and being the edition over 3 outweighed the Tetraphobia concerns